### PR TITLE
Update loot drops 

### DIFF
--- a/rotmg_loot_drops_updated.csv
+++ b/rotmg_loot_drops_updated.csv
@@ -48,6 +48,7 @@ White or ST,Ring of the Inferno,4.0
 White or ST,Demon Blade,4.0
 White or ST,Volcanic Sheath,4.0
 White or ST,Berserker's Breastplate,4.0
+White or ST,Adamantine Helm,6.0
 White or ST,Sword of Illumination,4.0
 White or ST,Cactus Juice,0
 White or ST,Wine Cellar Incantation,0
@@ -547,7 +548,7 @@ White or ST,Warmonger,10.0
 White or ST,Peacekeeper,10.0
 White or ST,Noble Mandolin,10.0
 White or ST,The Forgotten Crown,10.0
-White or ST,Chrysalis of Eternity,10.0
+White or ST,Chrysalis of Eternity,20.0
 White or ST,Corruption Tether,10.0
 White or ST,Ancient Eminence,10.0
 White or ST,Twilight Shroud,10.0
@@ -702,6 +703,7 @@ Biome White,Pollen Incendiary,10
 Biome White,Bloodbath Blade,10
 Biome White,Runes of Knowledge,10
 Biome White,Incubation Mace,10
+White or ST,Nightmatter Circlet,15.0
 White or ST,Vial of Soul Extract (shiny),0
 White or ST,Superior (shiny),19
 White or ST,Avarice (shiny),19


### PR DESCRIPTION
Added Adamantine Helm with a point rate of 6.0 and updated the drop rate of Chrysalis of Eternity to 20.0. Also added Nightmatter Circlet with a drop rate of 15.0.